### PR TITLE
FSR-595 Fix broken liquibase script

### DIFF
--- a/database/flooddev/u_flood/4.2.0/station_imtd_threshold.sql
+++ b/database/flooddev/u_flood/4.2.0/station_imtd_threshold.sql
@@ -18,7 +18,7 @@ ALTER SEQUENCE u_flood.station_imtd_threshold_station_threshold_id_seq
 
 CREATE TABLE IF NOT EXISTS u_flood.station_imtd_threshold
 (
-    station_threshold_id bigint NOT NULL DEFAULT nextval('station_threshold_station_threshold_id_seq'::regclass),
+    station_threshold_id bigint NOT NULL DEFAULT nextval('station_imtd_threshold_station_threshold_id_seq'::regclass),
     station_id bigint NOT NULL,
     fwis_code text NOT NULL,
     fwis_type char NOT NULL,


### PR DESCRIPTION
The table and sequence was renamed in an earlier commit but this was
missed.

Looks like the script was dropping and recreating the sequence correctly
but was actually using a preexisting sequence with the old name.

This only became apparent when running the script in an environment
where the original version had never been run (i.e. in the tst
environment)
