### PR TITLE
FSR-000 : add sql function to adjust telemetry data

### DIFF
--- a/database/flooddev/u_flood/setup/docker/Dockerfile
+++ b/database/flooddev/u_flood/setup/docker/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /db-init-scripts
 COPY docker/tablespaces.sql .
 COPY docker/roles.sql .
 COPY docker/database.sql .
+COPY docker/refresh-telemetry-function.sql .
 COPY ./non_rds_initial_setup.sql .
 RUN mkdir -p /wiyby/wiyby_tables /wiyby/wiyby_indexes
 RUN chown -R postgres:root /wiyby

--- a/database/flooddev/u_flood/setup/docker/README.md
+++ b/database/flooddev/u_flood/setup/docker/README.md
@@ -51,6 +51,22 @@ The database is updated using liquibase.
   * Scripts can be applied without having to do a full restore using `docker compose -f docker-compose.yml -f docker-compose-override.yml  -f docker-compose-liquibase.yml run --rm liquibase`
   * In the integration and production environments the Jenkins job `LFW_{STAGE}_02_UPDATE_DATABASE` will apply liquibase scripts  
 
+# Telemetry data refresh
+
+Since we are not currently running the flood data lambda's then the telemetry
+data is not updated and the data shown on the maps will get progressively more
+stale. Eventually, once there is no data for the last 5 days, the station will
+be flagged as having a data problem and no graph will be displayed.
+
+In order to resolve this, and to avoid a time consuming database refresh from
+one of the environments, there is a function called adjust_telemetry_timestamp
+which will identify the latest telemetry timestamp and correct it to make it now
+and also adjust all other timestamps by the same amount making the telemetry
+data appear current.
+
+This can be executed in the running flood-db container:
+
+`docker compose exec flood-db psql postgres://u_flood:secret@flood-db:5432/flooddev -c "SELECT adjust_telemetry_timestamps();"`
 
 # To run the pgTap DB tests
 

--- a/database/flooddev/u_flood/setup/docker/db_setup.sh
+++ b/database/flooddev/u_flood/setup/docker/db_setup.sh
@@ -6,6 +6,10 @@ psql -f /db-init-scripts/non_rds_initial_setup.sql
 # change 'secret' below to your prefered password
 psql -c "ALTER USER u_flood WITH PASSWORD 'secret';"
 
+# Note: need to use --database rather than PGDATABASE as the
+# earlier scripts will fail otherwise
 psql --dbname flooddev -f /backup/flood-db.bak
+
+psql --dbname flooddev -f /db-init-scripts/refresh-telemetry-function.sql
 
 echo "Database refresh complete"

--- a/database/flooddev/u_flood/setup/docker/docker-compose-liquibase.yml
+++ b/database/flooddev/u_flood/setup/docker/docker-compose-liquibase.yml
@@ -8,6 +8,8 @@ services:
         condition: service_healthy
     volumes:
       - ../..:/liquibase/u_flood
+    networks:
+      cff-internal:
     command: [ 
       "--username=postgres",
       "--password=postgres",
@@ -19,3 +21,6 @@ services:
       "--searchPath=/liquibase/u_flood/changelog,/liquibase/u_flood",
       "update"
     ]
+
+networks:
+  cff-internal:

--- a/database/flooddev/u_flood/setup/docker/docker-compose.yml
+++ b/database/flooddev/u_flood/setup/docker/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
+    image: flood-db
     shm_size: 1g
     environment:
       PGDATA: /pgdata
@@ -14,6 +15,8 @@ services:
     volumes:
       - pgdata:/pgdata
       - wiyby:/wiyby
+    networks:
+      cff-internal:
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
@@ -23,4 +26,9 @@ services:
 
 volumes: 
   pgdata:
+    name: flood-db-pgdata
   wiyby:
+    name: flood-db-wiyby
+
+networks:
+  cff-internal:

--- a/database/flooddev/u_flood/setup/docker/refresh-telemetry-function.sql
+++ b/database/flooddev/u_flood/setup/docker/refresh-telemetry-function.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE FUNCTION adjust_telemetry_timestamps() RETURNS VOID AS $$
+DECLARE 
+    time_shift INTERVAL;
+BEGIN
+    -- Compute the time difference
+    SELECT NOW() - MAX(value_timestamp) INTO time_shift FROM sls_telemetry_value;
+
+    -- Display the time shift value for diagnostic purposes
+    RAISE NOTICE 'Adjusting telemetry, it may take a minute or two. (Time shift: %)', time_shift;
+
+    -- Update sls_telemetry_value
+    UPDATE sls_telemetry_value
+    SET value_timestamp = value_timestamp + time_shift;
+
+    -- Update sls_telemetry_value_parent
+    UPDATE sls_telemetry_value_parent
+    SET 
+        imported = imported + time_shift,
+        start_timestamp = start_timestamp + time_shift,
+        end_timestamp = end_timestamp + time_shift;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
This makes the data appear current by 'pulling' it forward in time so the readings are moved forward by the diff between now and the last telemetry timestamp. It should be called on demand.

Also, made the network name specific and named the volumes for ease of management.
