### PR TITLE
FSR-1564 | Rainfall duplicates new

### DIFF
--- a/database/flooddev/u_flood/4.11.0/add_telemetry_value_parent_unique_constraint.sql
+++ b/database/flooddev/u_flood/4.11.0/add_telemetry_value_parent_unique_constraint.sql
@@ -1,0 +1,34 @@
+-- 4.11.0 - Remove duplicate Rainfall values and prevent recurrence (FSR-1564)
+-- Duplicate key for cleanup: (station, region, value_timestamp)
+-- Keep newest telemetry_value_id and delete older duplicates.
+
+WITH ranked AS (
+        SELECT
+                v.telemetry_value_id,
+                ROW_NUMBER() OVER (
+                        PARTITION BY p.station, p.region, v.value_timestamp
+                        ORDER BY v.telemetry_value_id DESC
+                ) AS rn
+        FROM u_flood.sls_telemetry_value_parent p
+        JOIN u_flood.sls_telemetry_value v
+            ON v.telemetry_value_parent_id = p.telemetry_value_parent_id
+        WHERE p.parameter = 'Rainfall'
+)
+DELETE FROM u_flood.sls_telemetry_value v
+USING ranked r
+WHERE v.telemetry_value_id = r.telemetry_value_id
+    AND r.rn > 1;
+
+-- Guardrail: prevent duplicate Rainfall parent streams being created.
+-- Null qualifier values are normalised via COALESCE so duplicates with NULL
+-- qualifier are still blocked.
+CREATE UNIQUE INDEX idx_sls_tvp_rainfall_unique_stream
+ON u_flood.sls_telemetry_value_parent
+(
+                station,
+                region,
+                COALESCE(qualifier, ''),
+                start_timestamp,
+                end_timestamp
+)
+WHERE lower(parameter) = 'rainfall';

--- a/database/flooddev/u_flood/4.11.0/add_telemetry_value_parent_unique_constraint.sql
+++ b/database/flooddev/u_flood/4.11.0/add_telemetry_value_parent_unique_constraint.sql
@@ -1,7 +1,49 @@
 -- 4.11.0 - Remove duplicate Rainfall values and prevent recurrence (FSR-1564)
--- Duplicate key for cleanup: (station, region, value_timestamp)
--- Keep newest telemetry_value_id and delete older duplicates.
 
+-- Step 1: if there are duplicate parent rows for the same stream,
+-- keep the most recently imported one.
+-- Then point child values at that kept parent row.
+WITH ranked_parent AS (
+        SELECT
+                p.telemetry_value_parent_id,
+                ROW_NUMBER() OVER (
+                        PARTITION BY p.station, p.region, COALESCE(p.qualifier, ''), p.start_timestamp, p.end_timestamp
+                        ORDER BY p.imported DESC, p.telemetry_value_parent_id DESC
+                ) AS rn,
+                FIRST_VALUE(p.telemetry_value_parent_id) OVER (
+                        PARTITION BY p.station, p.region, COALESCE(p.qualifier, ''), p.start_timestamp, p.end_timestamp
+                        ORDER BY p.imported DESC, p.telemetry_value_parent_id DESC
+                ) AS keep_parent_id
+        FROM u_flood.sls_telemetry_value_parent p
+        WHERE lower(p.parameter) = 'rainfall'
+), duplicate_parent AS (
+        SELECT telemetry_value_parent_id AS duplicate_parent_id, keep_parent_id
+        FROM ranked_parent
+        WHERE rn > 1
+)
+UPDATE u_flood.sls_telemetry_value v
+SET telemetry_value_parent_id = dp.keep_parent_id
+FROM duplicate_parent dp
+WHERE v.telemetry_value_parent_id = dp.duplicate_parent_id;
+
+-- Step 2: remove the now-unused duplicate parent rows.
+WITH ranked_parent AS (
+        SELECT
+                p.telemetry_value_parent_id,
+                ROW_NUMBER() OVER (
+                        PARTITION BY p.station, p.region, COALESCE(p.qualifier, ''), p.start_timestamp, p.end_timestamp
+                        ORDER BY p.imported DESC, p.telemetry_value_parent_id DESC
+                ) AS rn
+        FROM u_flood.sls_telemetry_value_parent p
+        WHERE lower(p.parameter) = 'rainfall'
+)
+DELETE FROM u_flood.sls_telemetry_value_parent p
+USING ranked_parent rp
+WHERE p.telemetry_value_parent_id = rp.telemetry_value_parent_id
+    AND rp.rn > 1;
+
+-- Step 3: clean up duplicate rainfall values (same station/region/timestamp).
+-- Keep the latest row by id.
 WITH ranked AS (
         SELECT
                 v.telemetry_value_id,
@@ -19,9 +61,8 @@ USING ranked r
 WHERE v.telemetry_value_id = r.telemetry_value_id
     AND r.rn > 1;
 
--- Guardrail: prevent duplicate Rainfall parent streams being created.
--- Null qualifier values are normalised via COALESCE so duplicates with NULL
--- qualifier are still blocked.
+-- Step 4: add a partial unique index so duplicate rainfall parent streams
+-- cannot be inserted again.
 CREATE UNIQUE INDEX idx_sls_tvp_rainfall_unique_stream
 ON u_flood.sls_telemetry_value_parent
 (

--- a/database/flooddev/u_flood/changelog/db.changelog-4.11.0.xml
+++ b/database/flooddev/u_flood/changelog/db.changelog-4.11.0.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" 
+xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xmlns:ora="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+	<changeSet author="Lee" id="4.11.0-0">
+		<sqlFile path="./4.11.0/add_telemetry_value_parent_unique_constraint.sql" splitStatements="false"/>
+	</changeSet>
+</databaseChangeLog>

--- a/database/flooddev/u_flood/changelog/db.changelog-master.xml
+++ b/database/flooddev/u_flood/changelog/db.changelog-master.xml
@@ -70,4 +70,6 @@ xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liqui
 	<include file="./changelog/db.changelog-4.8.0.xml" />
 	<include file="./changelog/db.changelog-4.9.0.xml" />
 	<include file="./changelog/db.changelog-4.10.0.xml" />
+	<!-- Upstream uniqueness constraint to prevent duplicate telemetry records-->
+	<include file="./changelog/db.changelog-4.11.0.xml" />
 </databaseChangeLog>


### PR DESCRIPTION
Summarise the changes:

Added change 4.11.0 which does the following in 4 stages:

Step 1 If it finds duplicate telemetry_value_parent rows it remaps child rows to one kept parent.
Step 2 It deletes duplicate parent rows from telemetry_value_parent
Step 3 It then deletes duplicate rainfall values from telemetry_value table
Step 4 It adds a guard rail to sls_telemetry_value_parent to stop duplicated being inserted in future